### PR TITLE
Return certificate and accept token in client

### DIFF
--- a/src/Kmd.Logic.FileSecurity.Client/FileSecurityClient.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/FileSecurityClient.cs
@@ -42,7 +42,7 @@ namespace Kmd.Logic.FileSecurity.Client
         /// </summary>
         /// <param name="httpClient">The HTTP client to use. The caller is expected to manage this resource and it will not be disposed.</param>
         /// <param name="options">The required configuration options.</param>
-        /// <param name="bearerToken">This is required to get certificate from File Security.</param>
+        /// <param name="bearerToken">Required access token to authenticate with File Security module.</param>
         public FileSecurityClient(
            HttpClient httpClient,
            string bearerToken,
@@ -361,7 +361,7 @@ namespace Kmd.Logic.FileSecurity.Client
                 credentials = new TokenCredentials(this.bearerToken);
                 this.internalClient = new InternalClient(credentials)
                 {
-                    BaseUri = this.options.FileSecurityServiceUri,
+                    BaseUri = this.options.FileSecurityServiceUri
                 };
             }
             else

--- a/src/Kmd.Logic.FileSecurity.Client/FileSecurityClient.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/FileSecurityClient.cs
@@ -27,16 +27,29 @@ namespace Kmd.Logic.FileSecurity.Client
         /// <param name="httpClient">The HTTP client to use. The caller is expected to manage this resource and it will not be disposed.</param>
         /// <param name="tokenProviderFactory">The Logic access token provider factory.</param>
         /// <param name="options">The required configuration options.</param>
-        /// <param name="bearerToken">This is required to get certificate from File Security</param>
         public FileSecurityClient(
             HttpClient httpClient,
             ITokenProviderFactory tokenProviderFactory,
-            FileSecurityOptions options,
-            string bearerToken = "")
+            FileSecurityOptions options)
         {
             this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.tokenProviderFactory = tokenProviderFactory ?? throw new ArgumentNullException(nameof(tokenProviderFactory));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FileSecurityClient"/> class using bearer token.
+        /// </summary>
+        /// <param name="httpClient">The HTTP client to use. The caller is expected to manage this resource and it will not be disposed.</param>
+        /// <param name="options">The required configuration options.</param>
+        /// <param name="bearerToken">This is required to get certificate from File Security.</param>
+        public FileSecurityClient(
+           HttpClient httpClient,
+           string bearerToken,
+           FileSecurityOptions options)
+        {
+            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
             this.bearerToken = bearerToken ?? throw new ArgumentNullException(nameof(bearerToken));
         }
 

--- a/src/Kmd.Logic.FileSecurity.Client/FileSecurityClient.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/FileSecurityClient.cs
@@ -361,7 +361,7 @@ namespace Kmd.Logic.FileSecurity.Client
                 credentials = new TokenCredentials(this.bearerToken);
                 this.internalClient = new InternalClient(credentials)
                 {
-                    BaseUri = this.options.FileSecurityServiceUri
+                    BaseUri = this.options.FileSecurityServiceUri,
                 };
             }
             else

--- a/src/Kmd.Logic.FileSecurity.Client/IInternalClient.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/IInternalClient.cs
@@ -191,13 +191,16 @@ namespace Kmd.Logic.FileSecurity.Client
         /// <param name='signConfigurationId'>
         /// Identifier of sign configuration to be used.
         /// </param>
+        /// <param name='requireCertificate'>
+        /// If true, will return the certificate
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        Task<HttpOperationResponse<SignConfigurationPdfResponse>> GetPdfSignConfigurationWithHttpMessagesAsync(System.Guid subscriptionId, System.Guid signConfigurationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<SignConfigurationPdfResponse>> GetPdfSignConfigurationWithHttpMessagesAsync(System.Guid subscriptionId, System.Guid signConfigurationId, bool? requireCertificate = false, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Updates a sign configuration for pdf document type

--- a/src/Kmd.Logic.FileSecurity.Client/InternalClient.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/InternalClient.cs
@@ -1486,6 +1486,9 @@ namespace Kmd.Logic.FileSecurity.Client
         /// <param name='signConfigurationId'>
         /// Identifier of sign configuration to be used.
         /// </param>
+        /// <param name='requireCertificate'>
+        /// If true, will return the certificate
+        /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>
@@ -1501,7 +1504,7 @@ namespace Kmd.Logic.FileSecurity.Client
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<SignConfigurationPdfResponse>> GetPdfSignConfigurationWithHttpMessagesAsync(System.Guid subscriptionId, System.Guid signConfigurationId, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<SignConfigurationPdfResponse>> GetPdfSignConfigurationWithHttpMessagesAsync(System.Guid subscriptionId, System.Guid signConfigurationId, bool? requireCertificate = false, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Tracing
             bool _shouldTrace = ServiceClientTracing.IsEnabled;
@@ -1512,6 +1515,7 @@ namespace Kmd.Logic.FileSecurity.Client
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("subscriptionId", subscriptionId);
                 tracingParameters.Add("signConfigurationId", signConfigurationId);
+                tracingParameters.Add("requireCertificate", requireCertificate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "GetPdfSignConfiguration", tracingParameters);
             }
@@ -1520,6 +1524,15 @@ namespace Kmd.Logic.FileSecurity.Client
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "subscriptions/{subscriptionId}/signconfigurations/pdf/{signConfigurationId}").ToString();
             _url = _url.Replace("{subscriptionId}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(subscriptionId, SerializationSettings).Trim('"')));
             _url = _url.Replace("{signConfigurationId}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(signConfigurationId, SerializationSettings).Trim('"')));
+            List<string> _queryParameters = new List<string>();
+            if (requireCertificate != null)
+            {
+                _queryParameters.Add(string.Format("requireCertificate={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(requireCertificate, SerializationSettings).Trim('"'))));
+            }
+            if (_queryParameters.Count > 0)
+            {
+                _url += "?" + string.Join("&", _queryParameters);
+            }
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;

--- a/src/Kmd.Logic.FileSecurity.Client/InternalClientExtensions.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/InternalClientExtensions.cs
@@ -353,9 +353,12 @@ namespace Kmd.Logic.FileSecurity.Client
             /// <param name='signConfigurationId'>
             /// Identifier of sign configuration to be used.
             /// </param>
-            public static SignConfigurationPdfResponse GetPdfSignConfiguration(this IInternalClient operations, System.Guid subscriptionId, System.Guid signConfigurationId)
+            /// <param name='requireCertificate'>
+            /// If true, will return the certificate
+            /// </param>
+            public static SignConfigurationPdfResponse GetPdfSignConfiguration(this IInternalClient operations, System.Guid subscriptionId, System.Guid signConfigurationId, bool? requireCertificate = false)
             {
-                return operations.GetPdfSignConfigurationAsync(subscriptionId, signConfigurationId).GetAwaiter().GetResult();
+                return operations.GetPdfSignConfigurationAsync(subscriptionId, signConfigurationId, requireCertificate).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -370,12 +373,15 @@ namespace Kmd.Logic.FileSecurity.Client
             /// <param name='signConfigurationId'>
             /// Identifier of sign configuration to be used.
             /// </param>
+            /// <param name='requireCertificate'>
+            /// If true, will return the certificate
+            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<SignConfigurationPdfResponse> GetPdfSignConfigurationAsync(this IInternalClient operations, System.Guid subscriptionId, System.Guid signConfigurationId, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<SignConfigurationPdfResponse> GetPdfSignConfigurationAsync(this IInternalClient operations, System.Guid subscriptionId, System.Guid signConfigurationId, bool? requireCertificate = false, CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.GetPdfSignConfigurationWithHttpMessagesAsync(subscriptionId, signConfigurationId, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.GetPdfSignConfigurationWithHttpMessagesAsync(subscriptionId, signConfigurationId, requireCertificate, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }

--- a/src/Kmd.Logic.FileSecurity.Client/Models/SignConfigurationPdfResponse.cs
+++ b/src/Kmd.Logic.FileSecurity.Client/Models/SignConfigurationPdfResponse.cs
@@ -24,7 +24,7 @@ namespace Kmd.Logic.FileSecurity.Client.Models
         /// Initializes a new instance of the SignConfigurationPdfResponse
         /// class.
         /// </summary>
-        public SignConfigurationPdfResponse(System.Guid? id = default(System.Guid?), string name = default(string), System.Guid? certificateId = default(System.Guid?), System.Guid? subscriptionId = default(System.Guid?), System.DateTime? createdDate = default(System.DateTime?), PdfPrivilegeModel pdfPrivilege = default(PdfPrivilegeModel))
+        public SignConfigurationPdfResponse(System.Guid? id = default(System.Guid?), string name = default(string), System.Guid? certificateId = default(System.Guid?), System.Guid? subscriptionId = default(System.Guid?), System.DateTime? createdDate = default(System.DateTime?), PdfPrivilegeModel pdfPrivilege = default(PdfPrivilegeModel), string certificateRawData = default(string))
         {
             Id = id;
             Name = name;
@@ -32,6 +32,7 @@ namespace Kmd.Logic.FileSecurity.Client.Models
             SubscriptionId = subscriptionId;
             CreatedDate = createdDate;
             PdfPrivilege = pdfPrivilege;
+            CertificateRawData = certificateRawData;
             CustomInit();
         }
 
@@ -69,6 +70,11 @@ namespace Kmd.Logic.FileSecurity.Client.Models
         /// </summary>
         [JsonProperty(PropertyName = "pdfPrivilege")]
         public PdfPrivilegeModel PdfPrivilege { get; set; }
+
+        /// <summary>
+        /// </summary>
+        [JsonProperty(PropertyName = "certificateRawData")]
+        public string CertificateRawData { get; set; }
 
     }
 }

--- a/src/Kmd.Logic.FileSecurity.Client/filesecurity.swagger.json
+++ b/src/Kmd.Logic.FileSecurity.Client/filesecurity.swagger.json
@@ -434,6 +434,13 @@
             "required": true,
             "type": "string",
             "format": "uuid"
+          },
+          {
+            "name": "requireCertificate",
+            "in": "query",
+            "description": "If true, will return the certificate",
+            "type": "boolean",
+            "default": false
           }
         ],
         "responses": {
@@ -701,6 +708,9 @@
         },
         "pdfPrivilege": {
           "$ref": "#/definitions/PdfPrivilegeModel"
+        },
+        "certificateRawData": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
- Updated client to return "Certificate" in the response of sign configuration privileges.
- Overloaded client constructor to accept bearer token.